### PR TITLE
Fix Android compilation issue with React Native 0.49

### DIFF
--- a/android/electrode-reactnative-bridge/src/androidTest/java/com/walmartlabs/electrode/reactnative/bridge/BaseBridgeTestCase.java
+++ b/android/electrode-reactnative-bridge/src/androidTest/java/com/walmartlabs/electrode/reactnative/bridge/BaseBridgeTestCase.java
@@ -67,7 +67,6 @@ public class BaseBridgeTestCase extends InstrumentationTestCase {
                     reactInstanceManager = ReactInstanceManager.builder()
                             .setApplication(instrumentation.newApplication(MyTestApplication.class.getClassLoader(), MyTestApplication.class.getName(), getInstrumentation().getContext()))
                             .setBundleAssetName("index.android.bundle")
-                            .setJSMainModuleName("index.android")
                             .addPackage(new MainReactPackage())
                             .setUseDeveloperSupport(false)
                             .setInitialLifecycleState(LifecycleState.BEFORE_CREATE)


### PR DESCRIPTION
Remove unnecessary call to `setJSMainModuleName` that was renamed to `setJSMainModulePath` in React Native 0.49.

This does not impact bridge clients, the compilation error was only for tests compilation !