### PR TITLE
Fix getConstants() ignores constantsProviders that are queued

### DIFF
--- a/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeBridgeHolder.java
+++ b/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeBridgeHolder.java
@@ -52,7 +52,6 @@ public final class ElectrodeBridgeHolder {
     private static final HashMap<String, EventListenerPlaceholder> mQueuedEventListenersRegistration = new HashMap<>();
     private static final HashMap<ElectrodeBridgeRequest, ElectrodeBridgeResponseListener<ElectrodeBridgeResponse>> mQueuedRequests = new HashMap<>();
     private static final List<ElectrodeBridgeEvent> mQueuedEvents = new ArrayList<>();
-    private static List<ConstantsProvider> constantsProviders = new ArrayList<>();
 
     static {
         ElectrodeBridgeTransceiver.registerReactNativeReadyListener(new ElectrodeBridgeTransceiver.ReactNativeReadyListener() {
@@ -64,7 +63,6 @@ public final class ElectrodeBridgeHolder {
                 registerQueuedRequestHandlers();
                 sendQueuedRequests();
                 emitQueuedEvents();
-                addConstantProviders();
             }
         });
 
@@ -146,11 +144,7 @@ public final class ElectrodeBridgeHolder {
     }
 
     public static void addConstantsProvider(@NonNull ConstantsProvider constantsProvider) {
-        if (!isReactNativeReady) {
-            ElectrodeBridgeHolder.constantsProviders.add(constantsProvider);
-            return;
-        }
-        electrodeNativeBridge.addConstantsProvider(constantsProvider);
+        ElectrodeBridgeTransceiver.addConstantsProvider(constantsProvider);
     }
 
     /**
@@ -205,14 +199,5 @@ public final class ElectrodeBridgeHolder {
             electrodeNativeBridge.sendEvent(event);
         }
         mQueuedEvents.clear();
-    }
-
-    private static void addConstantProviders() {
-        if (constantsProviders != null) {
-            for (ConstantsProvider provider : constantsProviders) {
-                electrodeNativeBridge.addConstantsProvider(provider);
-            }
-        }
-        constantsProviders.clear();
     }
 }

--- a/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeBridgeTransceiver.java
+++ b/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeBridgeTransceiver.java
@@ -54,10 +54,8 @@ class ElectrodeBridgeTransceiver extends ReactContextBaseJavaModule implements E
     private static final EventDispatcher sEventDispatcher = new EventDispatcherImpl(sEventRegistrar);
     private static final RequestRegistrar<ElectrodeBridgeRequestHandler<ElectrodeBridgeRequest, Object>> sRequestRegistrar = new RequestRegistrarImpl<>();
     private static final RequestDispatcher sRequestDispatcher = new RequestDispatcherImpl(sRequestRegistrar);
-
+    private static final List<ConstantsProvider> sConstantsProviders = new ArrayList<>();
     private static boolean sIsReactNativeReady;
-
-    private List<ConstantsProvider> constantsProviders = new ArrayList<>();
 
     /**
      * Initializes a new instance of ElectrodeBridgeTransceiver
@@ -114,10 +112,10 @@ class ElectrodeBridgeTransceiver extends ReactContextBaseJavaModule implements E
     @Nullable
     @Override
     public Map<String, Object> getConstants() {
-        if (constantsProviders != null && !constantsProviders.isEmpty()) {
+        if (sConstantsProviders != null && !sConstantsProviders.isEmpty()) {
             Map<String, Object> constants = new HashMap<>();
             try {
-                for (ConstantsProvider provider : constantsProviders) {
+                for (ConstantsProvider provider : sConstantsProviders) {
                     Map<String, Object> providerConstants;
                     if ((providerConstants = provider.getConstants()) != null) {
                         constants.putAll(providerConstants);
@@ -126,7 +124,7 @@ class ElectrodeBridgeTransceiver extends ReactContextBaseJavaModule implements E
                 return constants;
             } catch (Exception e) {
                 //GOTCHA: Added a try catch since the implementation of this would be on the client side and bridge has no control over unseen errors.
-                Logger.w(TAG, "getConstants() implementation by(%s) failed due to(%s)", constantsProviders, e.getMessage());
+                Logger.w(TAG, "getConstants() implementation by(%s) failed due to(%s)", sConstantsProviders, e.getMessage());
             }
         }
         return super.getConstants();
@@ -139,9 +137,13 @@ class ElectrodeBridgeTransceiver extends ReactContextBaseJavaModule implements E
         return sEventRegistrar.registerEventListener(name, eventListener, uuid);
     }
 
-    @Override
-    public void addConstantsProvider(@NonNull ConstantsProvider constantsProvider) {
-        this.constantsProviders.add(constantsProvider);
+    /**
+     * Registers the {@link ConstantsProvider} that will be used by the bridge module to get the constant values exposed to JavaScript
+     *
+     * @param constantsProvider
+     */
+    public static void addConstantsProvider(@NonNull ConstantsProvider constantsProvider) {
+        sConstantsProviders.add(constantsProvider);
     }
 
     @NonNull

--- a/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeNativeBridge.java
+++ b/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeNativeBridge.java
@@ -61,13 +61,6 @@ public interface ElectrodeNativeBridge {
     boolean addEventListener(@NonNull String name, @NonNull ElectrodeBridgeEventListener<ElectrodeBridgeEvent> eventListener, UUID uuid);
 
     /**
-     * Registers the listen that will be used by the bridge module to get the constant values exposed to JavaScript
-     *
-     * @param constantsProvider
-     */
-    void addConstantsProvider(@NonNull ConstantsProvider constantsProvider);
-
-    /**
      * Query UUID of the request handler
      *
      * @param name


### PR DESCRIPTION
Fixes #36 

ElectrodeBridgeHolder adds constantsProviders after ElectrodeBridgeTransceiver instance is created. While getConstants() method is invoked, constantsProviders list is still empty failing to export constants to JavaScript at runtime