### PR TITLE
Recreate Podspec file with dynamic version number

### DIFF
--- a/ElectrodeReactNativeBridge
+++ b/ElectrodeReactNativeBridge
@@ -1,0 +1,19 @@
+require 'json'
+version = JSON.parse(File.read('package.json'))["version"]
+
+Pod::Spec.new do |s|
+
+  s.name           = "ElectrodeReactNativeBridge"
+  s.version        = version
+  s.summary      = "React Native Electrode Bridge"
+
+  s.authors      = { "Cody Garvin" => "cgarvin@walmartlabs.com" }
+  s.homepage     = "https://github.com/electrode-io/react-native-electrode-bridge"
+  s.license      = "MIT"
+  s.platform     = :ios, "8.0"
+
+  s.source       = { :git => "https://github.com/electrode-io/react-native-electrode-bridge" }
+  s.source_files  = "ios/ElectrodeReactNativeBridge/*.{h,m}"
+
+  s.dependency 'React'
+end

--- a/ElectrodeReactNativeBridge
+++ b/ElectrodeReactNativeBridge
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.authors      = { "Cody Garvin" => "cgarvin@walmartlabs.com" }
   s.homepage     = "https://github.com/electrode-io/react-native-electrode-bridge"
   s.license      = "MIT"
-  s.platform     = :ios, "8.0"
+  s.platform     = :ios, "9.0"
 
   s.source       = { :git => "https://github.com/electrode-io/react-native-electrode-bridge" }
   s.source_files  = "ios/ElectrodeReactNativeBridge/*.{h,m}"


### PR DESCRIPTION
Many projects use Cocoapods to install native dependencies on iOS. This PR puts the necessary Podspec file back but with a dynamic version number pulled from `package.json`. 

