### PR TITLE
Update Processor return type and Fix Holder function signature

### DIFF
--- a/ios/ElectrodeReactNativeBridge/ElectrodeBridgeHolder.h
+++ b/ios/ElectrodeReactNativeBridge/ElectrodeBridgeHolder.h
@@ -43,13 +43,13 @@ NS_ASSUME_NONNULL_BEGIN
               requestCompletionHandler:
                   (ElectrodeBridgeRequestCompletionHandler)completion;
 
-+ (void)unregisterRequestHandlerWithUUID: (NSUUID *)uuid;
++ (nullable ElectrodeBridgeRequestCompletionHandler)unregisterRequestHandlerWithUUID: (NSUUID *)uuid;
 
 
 + (NSUUID *)addEventListenerWithName:(NSString *)name
                    eventListner:(ElectrodeBridgeEventListener)eventListner;
 
-+ (void)removeEventListener: (NSUUID *)UUID;
++ (nullable ElectrodeBridgeEventListener)removeEventListener: (NSUUID *)UUID;
 
 + (void)setBridge:(ElectrodeBridgeTransceiver *)bridge;
 + (void)addConstantsProvider:(id<ConstantsProvider>)constantsProvider;

--- a/ios/ElectrodeReactNativeBridge/ElectrodeBridgeHolder.m
+++ b/ios/ElectrodeReactNativeBridge/ElectrodeBridgeHolder.m
@@ -125,8 +125,8 @@ static NSMutableArray<id<ConstantsProvider>> *queuedConstantsProvider;
   }
 }
 
-+ (void)removeEventListener: (NSUUID *)UUID {
-    [electrodeNativeBridge removeEventListnerWithUUID: UUID];
++ (nullable ElectrodeBridgeEventListener)removeEventListener: (NSUUID *)UUID {
+    return [electrodeNativeBridge removeEventListnerWithUUID: UUID];
 }
 
 + (void)sendRequest:(ElectrodeBridgeRequest *)request
@@ -157,8 +157,8 @@ static NSMutableArray<id<ConstantsProvider>> *queuedConstantsProvider;
     return uuid;
 }
 
-+ (void)unregisterRequestHandlerWithUUID: (NSUUID *)uuid {
-    [electrodeNativeBridge unregisterRequestHandlerWithUUID:uuid];
++ (nullable ElectrodeBridgeRequestCompletionHandler)unregisterRequestHandlerWithUUID: (NSUUID *)uuid {
+    return [electrodeNativeBridge unregisterRequestHandlerWithUUID:uuid];
 }
 
 + (NSUUID *)addEventListenerWithName:(NSString *)name

--- a/ios/ElectrodeReactNativeBridge/ElectrodeBridgeProtocols.h
+++ b/ios/ElectrodeReactNativeBridge/ElectrodeBridgeProtocols.h
@@ -91,7 +91,7 @@ typedef void (^ElectrodeBridgeEventListener)(id _Nullable eventPayload);
  * @param uuid returned when register a request handler
  */
 
-- (void)unregisterRequestHandlerWithUUID: (NSUUID *)uuid;
+- (nullable ElectrodeBridgeRequestCompletionHandler)unregisterRequestHandlerWithUUID: (NSUUID *)uuid;
 
 /**
  * Sends an event with payload to all the event listeners
@@ -114,7 +114,7 @@ typedef void (^ElectrodeBridgeEventListener)(id _Nullable eventPayload);
  * Remove an event listener
  * @param uuid returned when listner is added.
  */
-- (void)removeEventListnerWithUUID: (NSUUID *) uuid;
+- (nullable ElectrodeBridgeEventListener)removeEventListnerWithUUID: (NSUUID *) uuid;
 
 - (void)addConstantsProvider:(id<ConstantsProvider>)constantsProvider;
 

--- a/ios/ElectrodeReactNativeBridge/ElectrodeBridgeTransceiver.m
+++ b/ios/ElectrodeReactNativeBridge/ElectrodeBridgeTransceiver.m
@@ -132,8 +132,8 @@ RCT_EXPORT_MODULE(ElectrodeBridge);
 }
 
 
-- (void) unregisterRequestHandlerWithUUID:(NSUUID *)uuid {
-    [requestRegistrar unregisterRequestHandler:uuid];
+- (nullable ElectrodeBridgeRequestCompletionHandler) unregisterRequestHandlerWithUUID:(NSUUID *)uuid {
+    return [requestRegistrar unregisterRequestHandler:uuid];
 }
 
 - (void)resetRegistrar {
@@ -155,9 +155,9 @@ RCT_EXPORT_MODULE(ElectrodeBridge);
   [self.eventDispatcher.eventRegistrar registerEventListener:eventListener
                                                           name:name uuid:uuid];
 }
-- (void)removeEventListnerWithUUID: (NSUUID *) uuid {
+- (nullable ElectrodeBridgeEventListener)removeEventListnerWithUUID: (NSUUID *) uuid {
     ERNDebug(@"Removing event listener with NNUUID with string %@", uuid.UUIDString);
-    [eventRegistrar unregisterEventListener:uuid];
+    return [eventRegistrar unregisterEventListener:uuid];
 }
 #pragma ElectrodeReactBridge
 

--- a/ios/ElectrodeReactNativeBridge/ElectrodeEventRegistrar.h
+++ b/ios/ElectrodeReactNativeBridge/ElectrodeEventRegistrar.h
@@ -36,7 +36,7 @@
 
  @param eventListenerUUID The UUID of the event listener.
  */
-- (void)unregisterEventListener:(NSUUID *_Nonnull)eventListenerUUID;
+- (nullable ElectrodeBridgeEventListener)unregisterEventListener:(NSUUID *_Nonnull)eventListenerUUID;
 
 /**
  Grabs all of the event listeners of a given name.

--- a/ios/ElectrodeReactNativeBridge/ElectrodeEventRegistrar.m
+++ b/ios/ElectrodeReactNativeBridge/ElectrodeEventRegistrar.m
@@ -43,10 +43,10 @@
   }
 }
 
-- (void)unregisterEventListener:(NSUUID *_Nonnull)eventListenerUUID {
-  @synchronized(self) {
-
-    ElectrodeBridgeEventListener eventListener =
+- (nullable ElectrodeBridgeEventListener) unregisterEventListener:(NSUUID *_Nonnull)eventListenerUUID {
+    ElectrodeBridgeEventListener eventListener;
+    @synchronized(self) {
+    eventListener =
         [self.eventListenerByUUID objectForKey:eventListenerUUID];
     [self.eventListenerByUUID removeObjectForKey:eventListenerUUID];
 
@@ -62,6 +62,7 @@
       }
     }
   }
+    return eventListener;
 }
 
 - (NSArray<ElectrodeBridgeEventListener> *_Nullable)getEventListnersForName:

--- a/ios/ElectrodeReactNativeBridge/ElectrodeRequestHandlerProcessor.swift
+++ b/ios/ElectrodeReactNativeBridge/ElectrodeRequestHandlerProcessor.swift
@@ -38,8 +38,8 @@ public class ElectrodeRequestHandlerProcessor<TReq, TResp>: NSObject, Processor 
         super.init()
     }
 
-    public func execute() {
-        ElectrodeBridgeHolder.registerRequestHandler(withName: requestName) { (data: Any?, responseCompletion: @escaping ElectrodeBridgeResponseCompletionHandler) in
+    public func execute() -> UUID? {
+        let uuid = ElectrodeBridgeHolder.registerRequestHandler(withName: requestName) { (data: Any?, responseCompletion: @escaping ElectrodeBridgeResponseCompletionHandler) in
             let request: Any?
             if self.reqClass == None.self {
                 request = nil
@@ -53,5 +53,6 @@ public class ElectrodeRequestHandlerProcessor<TReq, TResp>: NSObject, Processor 
             //this is passed back to Native side.
             self.requestCompletionHandler(request, responseCompletion)
         }
+        return uuid
     }
 }

--- a/ios/ElectrodeReactNativeBridge/ElectrodeRequestProcessor.swift
+++ b/ios/ElectrodeReactNativeBridge/ElectrodeRequestProcessor.swift
@@ -40,7 +40,7 @@ public class ElectrodeRequestProcessor<TReq, TResp, TItem>: NSObject {
         super.init()
     }
 
-    public func execute() {
+    public func execute() -> UUID? {
         ElectrodeConsoleLogger.sharedInstance().debug("RequestProcessor started processing request (\(requestName)) with payload (\(String(describing: requestPayload)))")
         let bridgeMessageData = ElectrodeUtilities.convertObjectToBridgeMessageData(object: requestPayload)
 
@@ -59,6 +59,7 @@ public class ElectrodeRequestProcessor<TReq, TResp, TItem>: NSObject {
                 self.responseCompletionHandler(processedResp, nil)
             }
         }
+        return nil
     }
 
     private func processSuccessResponse(responseData: Any?) -> Any? {

--- a/ios/ElectrodeReactNativeBridge/ElectrodeRequestRegistrar.h
+++ b/ios/ElectrodeReactNativeBridge/ElectrodeRequestRegistrar.h
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
  * registerRequestHandler
  * call
  */
-- (void)unregisterRequestHandler:(NSUUID *)uuid;
+- (nullable ElectrodeBridgeRequestCompletionHandler)unregisterRequestHandler:(NSUUID *)uuid;
 
 /**
  Grabs a given request handler for a request name.

--- a/ios/ElectrodeReactNativeBridge/ElectrodeRequestRegistrar.m
+++ b/ios/ElectrodeReactNativeBridge/ElectrodeRequestRegistrar.m
@@ -38,15 +38,18 @@ NS_ASSUME_NONNULL_BEGIN
   }
 }
 
-- (void)unregisterRequestHandler:(NSUUID *)uuid {
+- (nullable ElectrodeBridgeRequestCompletionHandler)unregisterRequestHandler:(NSUUID *)uuid {
+  ElectrodeBridgeRequestCompletionHandler handler;
   @synchronized(self) {
-    NSUUID *requestName = [self.requestNameByUUID objectForKey:uuid];
+    NSString *requestName = [self.requestNameByUUID objectForKey:uuid];
 
     if (requestName) {
       [self.requestNameByUUID removeObjectForKey:uuid];
+      handler = [self.requestHandlerByRequestName objectForKey:requestName];
       [self.requestHandlerByRequestName removeObjectForKey:requestName];
     }
   }
+  return handler;
 }
 
 - (nullable ElectrodeBridgeRequestCompletionHandler)getRequestHandler:

--- a/ios/ElectrodeReactNativeBridge/EventListenerProcessor.swift
+++ b/ios/ElectrodeReactNativeBridge/EventListenerProcessor.swift
@@ -31,11 +31,12 @@ public class EventListenerProcessor<T>: NSObject, Processor {
         super.init()
     }
 
-    public func execute() {
-        ElectrodeBridgeHolder.addEventListener(withName: eventName, eventListner: { (eventPayload: Any?) in
+    public func execute() -> UUID? {
+        let uuid = ElectrodeBridgeHolder.addEventListener(withName: eventName, eventListner: { (eventPayload: Any?) in
             self.logger.debug("Processing final result for the event with payload bundle (\(String(describing: eventPayload)))")
             let result = try? NSObject.generateObject(data: eventPayload as AnyObject, classType: self.eventPayloadClass)
             self.appEventListener(result)
         })
+        return uuid
     }
 }

--- a/ios/ElectrodeReactNativeBridge/EventProcessor.swift
+++ b/ios/ElectrodeReactNativeBridge/EventProcessor.swift
@@ -29,9 +29,10 @@ public class EventProcessor<T>: NSObject, Processor {
         super.init()
     }
 
-    public func execute() {
+    public func execute() -> UUID? {
         logger.debug("\(tag) EventProcessor is emitting event (\(eventName)) with payload (\(String(describing: eventPayload)))")
         let event = ElectrodeBridgeEvent(name: eventName, type: .event, data: eventPayload)
         ElectrodeBridgeHolder.send(event)
+        return nil
     }
 }

--- a/ios/ElectrodeReactNativeBridge/Processor.swift
+++ b/ios/ElectrodeReactNativeBridge/Processor.swift
@@ -17,5 +17,5 @@
 import Foundation
 
 @objc public protocol Processor {
-    func execute()
+    func execute() -> UUID?
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-electrode-bridge",
-  "version": "1.5.12",
+  "version": "1.5.13",
   "description": "Low level communication bridge between reaact native js and native",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- To support removeListener and unregisterListener, we need to return UUID from ElectrodeBridgeHolder. 
- On top of that, the processor needs to return UUID as well. This involves changing the protocol `processor` signature and corresponding processors. 