### PR TITLE
Document message types in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,19 @@ $ npm install react-native
 
 Now depending on which part of the bridge(Android|iOS|JS) you are working on open the code in respective IDEs.
 
+# Bridge message types
+
+Communication through the Electrode Native bridge is based on message exchanges between JavaScript and the Native application. The Electrode Native bridge processes three message types: `Request`, `Response`, and `Event`.
+
+- `Request`   
+A Request message is used to request data from a receiver or to request an action to be performed by a receiver. A Request message always results in an associated response message that can contain either the requested data or indicate the result of an action. A Request message can optionally contain a payload. For any given Request message type, there can be only one associated receiver. The receiver handles the request and issues a response message. From a developer perspective, a Request message can be thought as being a method call.
+
+- `Response`    
+A Response message is the result of a single Request message. A Response message can optionally contain a payload. From a developer perspective, a Response message can be thought as the return value of a method. The value can be of a specific type or not (void).
+
+- `Event`  
+An Event message is a "fire and forget" message. The sender of the Event message does not expect a response --so the receiver is known as a listener. Unlike a Request message, an Event message can be received by multiple listeners. All registered listeners (on the JavaScript side and native side) for a specific event message type will receive the Event message.
+
 # How to use Electrode Native Bridge
 
 ## JavaScript


### PR DESCRIPTION
We are missing some documentation around the different message types exchanged through the bridge (this is documented in main Electrode Native documentation but not in this repo).

This PR is adding missing documentation, to address https://github.com/electrode-io/react-native-electrode-bridge/issues/52