### PR TITLE
Replace android.support with androidx

### DIFF
--- a/android/electrode-reactnative-bridge/build.gradle
+++ b/android/electrode-reactnative-bridge/build.gradle
@@ -27,7 +27,7 @@ android {
         ndk {
             abiFilters "armeabi-v7a", "x86"
         }
-        testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
         release {
@@ -43,9 +43,10 @@ android {
 dependencies {
     api fileTree(dir: 'libs', include: ['*.jar'])
 
-    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation 'com.facebook.react:react-native:+'
     androidTestImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 }

--- a/android/electrode-reactnative-bridge/src/androidTest/java/com/walmartlabs/electrode/reactnative/bridge/BaseBridgeTestCase.java
+++ b/android/electrode-reactnative-bridge/src/androidTest/java/com/walmartlabs/electrode/reactnative/bridge/BaseBridgeTestCase.java
@@ -19,9 +19,10 @@ package com.walmartlabs.electrode.reactnative.bridge;
 import android.app.Instrumentation;
 import android.os.Handler;
 import android.os.Looper;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.test.InstrumentationRegistry;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.test.platform.app.InstrumentationRegistry;
 
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.bridge.Arguments;

--- a/android/electrode-reactnative-bridge/src/androidTest/java/com/walmartlabs/electrode/reactnative/bridge/BridgeHolderTests.java
+++ b/android/electrode-reactnative-bridge/src/androidTest/java/com/walmartlabs/electrode/reactnative/bridge/BridgeHolderTests.java
@@ -1,7 +1,7 @@
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.walmartlabs.electrode.reactnative.bridge.helpers.Logger;
 

--- a/android/electrode-reactnative-bridge/src/androidTest/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeBridgeTransceiverTest.java
+++ b/android/electrode-reactnative-bridge/src/androidTest/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeBridgeTransceiverTest.java
@@ -17,8 +17,9 @@
 package com.walmartlabs.electrode.reactnative.bridge;
 
 import android.os.Bundle;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;

--- a/android/electrode-reactnative-bridge/src/androidTest/java/com/walmartlabs/electrode/reactnative/bridge/EventProcessorTest.java
+++ b/android/electrode-reactnative-bridge/src/androidTest/java/com/walmartlabs/electrode/reactnative/bridge/EventProcessorTest.java
@@ -16,7 +16,7 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import com.walmartlabs.electrode.reactnative.sample.api.PersonApi;
 import com.walmartlabs.electrode.reactnative.sample.model.Person;

--- a/android/electrode-reactnative-bridge/src/androidTest/java/com/walmartlabs/electrode/reactnative/bridge/RequestHandleTests.java
+++ b/android/electrode-reactnative-bridge/src/androidTest/java/com/walmartlabs/electrode/reactnative/bridge/RequestHandleTests.java
@@ -1,7 +1,7 @@
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.walmartlabs.electrode.reactnative.sample.api.PersonApi;
 
@@ -166,7 +166,7 @@ public class RequestHandleTests extends BaseBridgeTestCase {
 
             @Override
             public void onFailure(@NonNull FailureMessage failureMessage) {
-               fail();
+                fail();
             }
         });
 

--- a/android/electrode-reactnative-bridge/src/androidTest/java/com/walmartlabs/electrode/reactnative/bridge/RequestProcessorTest.java
+++ b/android/electrode-reactnative-bridge/src/androidTest/java/com/walmartlabs/electrode/reactnative/bridge/RequestProcessorTest.java
@@ -17,8 +17,9 @@
 package com.walmartlabs.electrode.reactnative.bridge;
 
 import android.os.Bundle;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReadableArray;

--- a/android/electrode-reactnative-bridge/src/androidTest/java/com/walmartlabs/electrode/reactnative/sample/api/PersonApi.java
+++ b/android/electrode-reactnative-bridge/src/androidTest/java/com/walmartlabs/electrode/reactnative/sample/api/PersonApi.java
@@ -16,7 +16,7 @@
 
 package com.walmartlabs.electrode.reactnative.sample.api;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.walmartlabs.electrode.reactnative.bridge.ElectrodeBridgeEventListener;
 import com.walmartlabs.electrode.reactnative.bridge.ElectrodeBridgeRequestHandler;

--- a/android/electrode-reactnative-bridge/src/androidTest/java/com/walmartlabs/electrode/reactnative/sample/api/PersonEvents.java
+++ b/android/electrode-reactnative-bridge/src/androidTest/java/com/walmartlabs/electrode/reactnative/sample/api/PersonEvents.java
@@ -16,7 +16,7 @@
 
 package com.walmartlabs.electrode.reactnative.sample.api;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.walmartlabs.electrode.reactnative.bridge.ElectrodeBridgeEventListener;
 import com.walmartlabs.electrode.reactnative.bridge.EventListenerProcessor;

--- a/android/electrode-reactnative-bridge/src/androidTest/java/com/walmartlabs/electrode/reactnative/sample/api/PersonRequests.java
+++ b/android/electrode-reactnative-bridge/src/androidTest/java/com/walmartlabs/electrode/reactnative/sample/api/PersonRequests.java
@@ -16,7 +16,7 @@
 
 package com.walmartlabs.electrode.reactnative.sample.api;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.walmartlabs.electrode.reactnative.bridge.ElectrodeBridgeRequestHandler;
 import com.walmartlabs.electrode.reactnative.bridge.ElectrodeBridgeResponseListener;

--- a/android/electrode-reactnative-bridge/src/androidTest/java/com/walmartlabs/electrode/reactnative/sample/api/UpdatePersonRequestData.java
+++ b/android/electrode-reactnative-bridge/src/androidTest/java/com/walmartlabs/electrode/reactnative/sample/api/UpdatePersonRequestData.java
@@ -17,8 +17,9 @@
 package com.walmartlabs.electrode.reactnative.sample.api;
 
 import android.os.Bundle;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.walmartlabs.electrode.reactnative.bridge.Bridgeable;
 import com.walmartlabs.electrode.reactnative.sample.model.Status;

--- a/android/electrode-reactnative-bridge/src/androidTest/java/com/walmartlabs/electrode/reactnative/sample/model/Address.java
+++ b/android/electrode-reactnative-bridge/src/androidTest/java/com/walmartlabs/electrode/reactnative/sample/model/Address.java
@@ -19,8 +19,9 @@ package com.walmartlabs.electrode.reactnative.sample.model;
 import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.walmartlabs.electrode.reactnative.bridge.Bridgeable;
 

--- a/android/electrode-reactnative-bridge/src/androidTest/java/com/walmartlabs/electrode/reactnative/sample/model/BirthYear.java
+++ b/android/electrode-reactnative-bridge/src/androidTest/java/com/walmartlabs/electrode/reactnative/sample/model/BirthYear.java
@@ -19,8 +19,8 @@ package com.walmartlabs.electrode.reactnative.sample.model;
 import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+
+import androidx.annotation.NonNull;
 
 import com.walmartlabs.electrode.reactnative.bridge.Bridgeable;
 

--- a/android/electrode-reactnative-bridge/src/androidTest/java/com/walmartlabs/electrode/reactnative/sample/model/Person.java
+++ b/android/electrode-reactnative-bridge/src/androidTest/java/com/walmartlabs/electrode/reactnative/sample/model/Person.java
@@ -19,8 +19,9 @@ package com.walmartlabs.electrode.reactnative.sample.model;
 import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.walmartlabs.electrode.reactnative.bridge.Bridgeable;
 

--- a/android/electrode-reactnative-bridge/src/androidTest/java/com/walmartlabs/electrode/reactnative/sample/model/Position.java
+++ b/android/electrode-reactnative-bridge/src/androidTest/java/com/walmartlabs/electrode/reactnative/sample/model/Position.java
@@ -19,12 +19,11 @@ package com.walmartlabs.electrode.reactnative.sample.model;
 import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.walmartlabs.electrode.reactnative.bridge.Bridgeable;
-
-import static com.walmartlabs.electrode.reactnative.bridge.util.BridgeArguments.getNumberValue;
 
 public class Position implements Parcelable, Bridgeable {
 
@@ -88,7 +87,7 @@ public class Position implements Parcelable, Bridgeable {
     public Bundle toBundle() {
         Bundle bundle = new Bundle();
         bundle.putDouble("lat", lat);
-        if(lng != null) {
+        if (lng != null) {
             bundle.putDouble("lng", lng);
         }
         return bundle;

--- a/android/electrode-reactnative-bridge/src/androidTest/java/com/walmartlabs/electrode/reactnative/sample/model/Status.java
+++ b/android/electrode-reactnative-bridge/src/androidTest/java/com/walmartlabs/electrode/reactnative/sample/model/Status.java
@@ -19,12 +19,11 @@ package com.walmartlabs.electrode.reactnative.sample.model;
 import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.walmartlabs.electrode.reactnative.bridge.Bridgeable;
-
-import static com.walmartlabs.electrode.reactnative.bridge.util.BridgeArguments.getNumberValue;
 
 public class Status implements Parcelable, Bridgeable {
 
@@ -97,7 +96,7 @@ public class Status implements Parcelable, Bridgeable {
     @NonNull
     public Bundle toBundle() {
         Bundle bundle = new Bundle();
-        if(log != null) {
+        if (log != null) {
             bundle.putBoolean("log", log);
         }
         bundle.putBoolean("member", member);

--- a/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/BridgeFailureMessage.java
+++ b/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/BridgeFailureMessage.java
@@ -16,8 +16,8 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 public class BridgeFailureMessage implements FailureMessage {
 

--- a/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/BridgeMessage.java
+++ b/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/BridgeMessage.java
@@ -17,8 +17,9 @@
 package com.walmartlabs.electrode.reactnative.bridge;
 
 import android.os.Bundle;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReadableMap;

--- a/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/BridgeTransaction.java
+++ b/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/BridgeTransaction.java
@@ -16,8 +16,8 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 public class BridgeTransaction {
 

--- a/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/Bridgeable.java
+++ b/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/Bridgeable.java
@@ -17,7 +17,8 @@
 package com.walmartlabs.electrode.reactnative.bridge;
 
 import android.os.Bundle;
-import android.support.annotation.NonNull;
+
+import androidx.annotation.NonNull;
 
 /**
  * Indicates that any class that implements this interface can be sent across the ElectrodeNativeBridge.

--- a/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ConstantsProvider.java
+++ b/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ConstantsProvider.java
@@ -16,7 +16,7 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import java.util.Map;
 

--- a/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeBridgeEvent.java
+++ b/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeBridgeEvent.java
@@ -17,8 +17,9 @@
 package com.walmartlabs.electrode.reactnative.bridge;
 
 import android.os.Bundle;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.facebook.react.bridge.ReadableMap;
 import com.walmartlabs.electrode.reactnative.bridge.helpers.Logger;

--- a/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeBridgeEventListener.java
+++ b/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeBridgeEventListener.java
@@ -16,7 +16,7 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 /**
  * Provide method to be notified of incoming event

--- a/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeBridgeHolder.java
+++ b/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeBridgeHolder.java
@@ -16,8 +16,8 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.walmartlabs.electrode.reactnative.bridge.helpers.Logger;
 

--- a/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeBridgeRequest.java
+++ b/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeBridgeRequest.java
@@ -16,8 +16,8 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.facebook.react.bridge.ReadableMap;
 import com.walmartlabs.electrode.reactnative.bridge.helpers.Logger;

--- a/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeBridgeRequestHandler.java
+++ b/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeBridgeRequestHandler.java
@@ -16,8 +16,8 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /**
  * Provide method to be notified of incoming request.

--- a/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeBridgeResponse.java
+++ b/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeBridgeResponse.java
@@ -17,8 +17,9 @@
 package com.walmartlabs.electrode.reactnative.bridge;
 
 import android.os.Bundle;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReadableMap;

--- a/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeBridgeResponseListener.java
+++ b/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeBridgeResponseListener.java
@@ -16,8 +16,8 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /**
  * Provide methods to report response for a request.

--- a/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeBridgeTransceiver.java
+++ b/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeBridgeTransceiver.java
@@ -18,9 +18,10 @@ package com.walmartlabs.electrode.reactnative.bridge;
 
 import android.os.Handler;
 import android.os.Looper;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.VisibleForTesting;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;

--- a/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeNativeBridge.java
+++ b/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeNativeBridge.java
@@ -16,8 +16,8 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.util.UUID;
 

--- a/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeReactBridge.java
+++ b/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeReactBridge.java
@@ -16,7 +16,7 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.facebook.react.bridge.ReadableMap;
 

--- a/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/EventDispatcher.java
+++ b/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/EventDispatcher.java
@@ -16,7 +16,7 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 public interface EventDispatcher {
     void dispatchEvent(@NonNull ElectrodeBridgeEvent event);

--- a/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/EventDispatcherImpl.java
+++ b/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/EventDispatcherImpl.java
@@ -16,7 +16,7 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.walmartlabs.electrode.reactnative.bridge.helpers.Logger;
 

--- a/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/EventListenerProcessor.java
+++ b/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/EventListenerProcessor.java
@@ -16,8 +16,8 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.walmartlabs.electrode.reactnative.bridge.helpers.Logger;
 import com.walmartlabs.electrode.reactnative.bridge.util.BridgeArguments;

--- a/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/EventProcessor.java
+++ b/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/EventProcessor.java
@@ -16,12 +16,10 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.walmartlabs.electrode.reactnative.bridge.helpers.Logger;
-
-import java.util.UUID;
 
 /**
  * Processes an event that is emitted from Native side

--- a/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/EventRegistrar.java
+++ b/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/EventRegistrar.java
@@ -16,7 +16,7 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import java.util.List;
 import java.util.UUID;

--- a/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/EventRegistrarImpl.java
+++ b/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/EventRegistrarImpl.java
@@ -16,8 +16,8 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.VisibleForTesting;
+import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ExistingHandlerException.java
+++ b/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ExistingHandlerException.java
@@ -16,7 +16,7 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 /**
  * Exception thrown when trying to register a request handler for a request name that already

--- a/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/FailureMessage.java
+++ b/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/FailureMessage.java
@@ -16,8 +16,8 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /**
  * Bridge failure message interface.

--- a/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/None.java
+++ b/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/None.java
@@ -17,7 +17,8 @@
 package com.walmartlabs.electrode.reactnative.bridge;
 
 import android.os.Bundle;
-import android.support.annotation.NonNull;
+
+import androidx.annotation.NonNull;
 
 /**
  * Class that is used to represent an emplty request or response type.

--- a/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ReactContextWrapper.java
+++ b/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ReactContextWrapper.java
@@ -16,7 +16,7 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.facebook.react.bridge.ReactApplicationContext;
 

--- a/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ReactContextWrapperInternal.java
+++ b/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ReactContextWrapperInternal.java
@@ -16,7 +16,7 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.modules.core.DeviceEventManagerModule;

--- a/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/RequestDispatcher.java
+++ b/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/RequestDispatcher.java
@@ -16,7 +16,7 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 public interface RequestDispatcher {
 

--- a/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/RequestDispatcherImpl.java
+++ b/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/RequestDispatcherImpl.java
@@ -16,7 +16,7 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.walmartlabs.electrode.reactnative.bridge.helpers.Logger;
 
@@ -46,7 +46,7 @@ class RequestDispatcherImpl implements RequestDispatcher {
             responseListener.onFailure(failureMessage);
             return;
         }
-        requestHandler.onRequest(bridgeRequest,responseListener);
+        requestHandler.onRequest(bridgeRequest, responseListener);
     }
 
 

--- a/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/RequestHandlerProcessor.java
+++ b/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/RequestHandlerProcessor.java
@@ -16,8 +16,8 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.walmartlabs.electrode.reactnative.bridge.helpers.Logger;
 import com.walmartlabs.electrode.reactnative.bridge.util.BridgeArguments;

--- a/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/RequestProcessor.java
+++ b/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/RequestProcessor.java
@@ -16,8 +16,8 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.walmartlabs.electrode.reactnative.bridge.helpers.Logger;
 import com.walmartlabs.electrode.reactnative.bridge.util.BridgeArguments;

--- a/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/RequestRegistrar.java
+++ b/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/RequestRegistrar.java
@@ -16,8 +16,8 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.util.UUID;
 

--- a/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/RequestRegistrarImpl.java
+++ b/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/RequestRegistrarImpl.java
@@ -16,9 +16,9 @@
 
 package com.walmartlabs.electrode.reactnative.bridge;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.VisibleForTesting;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 
 import com.walmartlabs.electrode.reactnative.bridge.helpers.Logger;
 

--- a/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/helpers/ArgumentsEx.java
+++ b/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/helpers/ArgumentsEx.java
@@ -17,7 +17,8 @@
 package com.walmartlabs.electrode.reactnative.bridge.helpers;
 
 import android.os.Bundle;
-import android.support.annotation.NonNull;
+
+import androidx.annotation.NonNull;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReadableArray;
@@ -25,7 +26,6 @@ import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableMapKeySetIterator;
 import com.facebook.react.bridge.ReadableType;
 import com.facebook.react.bridge.WritableMap;
-import com.walmartlabs.electrode.reactnative.bridge.BridgeMessage;
 
 import javax.annotation.Nullable;
 
@@ -137,7 +137,7 @@ public class ArgumentsEx {
                     break;
                 case Array: {
                     ReadableArray readableArray = readableMap.getArray(key);
-                    if(readableArray.size() > 0) {
+                    if (readableArray.size() > 0) {
                         switch (readableArray.getType(0)) {
                             case String:
                                 bundle.putStringArray(key, ArgumentsEx.toStringArray(readableArray));

--- a/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/util/BridgeArguments.java
+++ b/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/util/BridgeArguments.java
@@ -17,9 +17,10 @@
 package com.walmartlabs.electrode.reactnative.bridge.util;
 
 import android.os.Bundle;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.VisibleForTesting;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 
 import com.walmartlabs.electrode.reactnative.bridge.BridgeMessage;
 import com.walmartlabs.electrode.reactnative.bridge.Bridgeable;

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -16,7 +16,12 @@ org.gradle.jvmargs=-Xmx1536m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-android.useDeprecatedNdk=true
+# AndroidX package structure to make it clearer which packages are bundled with the
+# Android operating system, and which are packaged with your app's APK
+# https://developer.android.com/topic/libraries/support-library/androidx-rn
+android.useAndroidX=true
+# Automatically convert third-party libraries to use AndroidX
+android.enableJetifier=true
 
 mavenUser=
 mavenPassword=


### PR DESCRIPTION
This updates all dependencies to use `androidx.*` imports.

Other components of ERN (e.g. container generator) will be upgraded and released (if necessary as major version) in separate PRs.