### PR TITLE
Update Android test runner

### DIFF
--- a/android/electrode-reactnative-bridge/build.gradle
+++ b/android/electrode-reactnative-bridge/build.gradle
@@ -46,8 +46,6 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:28.0.0'
     implementation 'com.facebook.react:react-native:+'
     androidTestImplementation 'junit:junit:4.12'
-
-    androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
-        exclude group: 'com.android.support', module: 'support-annotations'
-    })
+    androidTestImplementation 'com.android.support.test:runner:1.0.2'
+    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
 }


### PR DESCRIPTION
Using the last version of non-androidx Espresso test runner and core as an attempt to fix the slow and flaky Travis CI instrumentation tests (before the eventual migration to GitHub Actions CI).