### PR TITLE
Set max event listeners to 100

### DIFF
--- a/js/ElectrodeBridge.js
+++ b/js/ElectrodeBridge.js
@@ -32,6 +32,7 @@ var EventEmitter = require('events')
 // specified. "error" and "data" are mutually exclusive
 //=====================================================
 
+const MAX_LISTENERS = 100
 
 // All messages (requests/responses/events) coming from the native side
 // will be transmitted as events with the following event name
@@ -318,4 +319,6 @@ export const DispatchMode = {
   GLOBAL: 2
 };
 
-export const electrodeBridge = new ElectrodeBridge()
+const electrodeBridge = new ElectrodeBridge()
+electrodeBridge.setMaxListeners(MAX_LISTENERS)
+export electrodeBridge


### PR DESCRIPTION
Bump max event listeners to `100` (from default of `10`), using [`setMaxListeners`](https://github.com/Gozala/events/blob/v1.1.1/events.js#L38-L45)

Note that this is not the max number of overall event listeners, but the max number of event listeners per event type/name.
