### PR TITLE
Post notification for when transceiver starts observing

### DIFF
--- a/ios/ElectrodeReactNativeBridge/ElectrodeBridgeHolder.h
+++ b/ios/ElectrodeReactNativeBridge/ElectrodeBridgeHolder.h
@@ -32,6 +32,8 @@ NS_ASSUME_NONNULL_BEGIN
  * Handles queuing every method calls until react native is ready.
  */
 
+extern NSString * const ElectrodeBridgeDidStartObservingNotification;
+
 @interface ElectrodeBridgeHolder : NSObject
 
 + (void)sendEvent:(ElectrodeBridgeEvent *)event;

--- a/ios/ElectrodeReactNativeBridge/ElectrodeBridgeHolder.m
+++ b/ios/ElectrodeReactNativeBridge/ElectrodeBridgeHolder.m
@@ -21,6 +21,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+NSString * const ElectrodeBridgeDidStartObservingNotification = @"ElectrodeBridgeDidStartObservingNotification";
+
 @interface ElectrodeQueuedEventListener: NSObject
 @property (nonatomic, strong) NSUUID *uuid;
 @property (copy) ElectrodeBridgeEventListener listener;

--- a/ios/ElectrodeReactNativeBridge/ElectrodeBridgeTransceiver.m
+++ b/ios/ElectrodeReactNativeBridge/ElectrodeBridgeTransceiver.m
@@ -22,6 +22,7 @@
 #import "ElectrodeEventRegistrar.h"
 #import "ElectrodeRequestRegistrar.h"
 #import "ElectrodeLogger.h"
+#import "ElectrodeBridgeHolder.h"
 
 #if __has_include(<React/RCTLog.h>)
 #import <React/RCTLog.h>
@@ -435,6 +436,10 @@ createTransactionWithRequest:(ElectrodeBridgeRequest *)request
   if (reactNativeTransceiver) {
     reactNativeTransceiver(self);
   }
+}
+
+- (void)startObserving {
+    [[NSNotificationCenter defaultCenter] postNotificationName:ElectrodeBridgeDidStartObservingNotification object:self];
 }
 
 @end


### PR DESCRIPTION
This PR creates a notification when ElectrodeBridgeTransceiver starts observing, which occurs after javascript is initialized. This lets observers of this notification know it is safe to begin passing events to javascript side. Notification is defined in ElectrodeBridgeHolder as comments say it is client facing facade class for ElectrodeBridgeTransceiver.