### PR TITLE
Remove strong references for delegates and completion handlers

### DIFF
--- a/ios/ElectrodeReactNativeBridge/ElectrodeBridgeResponse.h
+++ b/ios/ElectrodeReactNativeBridge/ElectrodeBridgeResponse.h
@@ -26,7 +26,7 @@ extern NSString *const kElectrodeBridgeResponseUnknownErrorCode;
 
 @interface ElectrodeBridgeResponse : ElectrodeBridgeMessage
 
-@property(readonly, nonatomic, strong, nullable) id<ElectrodeFailureMessage>
+@property(readonly, nonatomic, weak, nullable) id<ElectrodeFailureMessage>
     failureMessage;
 
 + (nullable instancetype)createResponseWithData:(NSDictionary *)data;

--- a/ios/ElectrodeReactNativeBridge/ElectrodeBridgeResponse.m
+++ b/ios/ElectrodeReactNativeBridge/ElectrodeBridgeResponse.m
@@ -24,7 +24,7 @@ NSString *const kElectrodeBridgeResponseUnknownErrorCode = @"EUNKNOWN";
 
 @interface ElectrodeBridgeResponse ()
 
-@property(nonatomic, strong, nullable) id<ElectrodeFailureMessage>
+@property(nonatomic, weak, nullable) id<ElectrodeFailureMessage>
     failureMessage;
 
 @end

--- a/ios/ElectrodeReactNativeBridge/ElectrodeBridgeTransaction.h
+++ b/ios/ElectrodeReactNativeBridge/ElectrodeBridgeTransaction.h
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ElectrodeBridgeTransaction : NSObject
 
 @property(nonatomic, readonly, strong) ElectrodeBridgeRequest *request;
-@property(nonatomic, readonly, strong, nullable) ElectrodeBridgeResponseCompletionHandler completion;
+@property(nonatomic, readonly, copy, nullable) ElectrodeBridgeResponseCompletionHandler completion;
 // Note: response can be set
 @property(nonatomic, readwrite, strong, nullable)
     ElectrodeBridgeResponse *response;

--- a/ios/ElectrodeReactNativeBridge/ElectrodeBridgeTransaction.m
+++ b/ios/ElectrodeReactNativeBridge/ElectrodeBridgeTransaction.m
@@ -20,7 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ElectrodeBridgeTransaction ()
 
 @property(nonatomic, strong, nonnull) ElectrodeBridgeRequest *request;
-@property(nonatomic, strong, nullable)
+@property(nonatomic, copy, nullable)
     ElectrodeBridgeResponseCompletionHandler completion;
 
 @end

--- a/ios/ElectrodeReactNativeBridge/ElectrodeBridgeTransceiver.m
+++ b/ios/ElectrodeReactNativeBridge/ElectrodeBridgeTransceiver.m
@@ -377,18 +377,18 @@ createTransactionWithRequest:(ElectrodeBridgeRequest *)request
                          @"always be set for a local transaction"];
     } else {
       if (response.failureMessage != nil) {
-
-        ERNDebug(@"Completing transaction by issuing a failure call back to "
-                 @"local response listener");
-        dispatch_async(dispatch_get_main_queue(), ^{
-          transaction.completion(nil, response.failureMessage);
-        });
+          ERNDebug(@"Completing transaction by issuing a failure call back to "
+                   @"local response listener");
+          ElectrodeBridgeFailureMessage *failureMessage = response.failureMessage;
+          dispatch_async(dispatch_get_main_queue(), ^{
+              transaction.completion(nil, failureMessage);
+          });
       } else {
-        ERNDebug(@"Completing transaction by issuing a success call back to "
-                 @"local response listener");
-        dispatch_async(dispatch_get_main_queue(), ^{
-          transaction.completion(response.data, nil);
-        });
+          ERNDebug(@"Completing transaction by issuing a success call back to "
+                   @"local response listener");
+          dispatch_async(dispatch_get_main_queue(), ^{
+              transaction.completion(response.data, nil);
+          });
       }
     }
   }


### PR DESCRIPTION
@belemaire Do you know if we need to dispatch calling the transaction completion handler on the main queue?