### PR TITLE
Add is registered

### DIFF
--- a/android/electrode-reactnative-bridge/src/androidTest/java/com/walmartlabs/electrode/reactnative/bridge/RequestHandleTests.java
+++ b/android/electrode-reactnative-bridge/src/androidTest/java/com/walmartlabs/electrode/reactnative/bridge/RequestHandleTests.java
@@ -10,8 +10,10 @@ import org.junit.Test;
 import java.util.concurrent.CountDownLatch;
 
 import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertNotNull;
 import static junit.framework.TestCase.assertSame;
+import static junit.framework.TestCase.assertTrue;
 import static junit.framework.TestCase.fail;
 
 public class RequestHandleTests extends BaseBridgeTestCase {
@@ -184,5 +186,46 @@ public class RequestHandleTests extends BaseBridgeTestCase {
         });
 
         waitForCountDownToFinishOrFail(countDownLatch);
+    }
+
+    @Test
+    public void testRequestHandlerIsRegisteredOnUnregister() {
+        final String requestName = "testRequestHandlerRemoval";
+
+        RequestHandlerHandle requestHandle = new RequestHandlerProcessor<>(requestName, None.class, None.class, new ElectrodeBridgeRequestHandler<None, None>() {
+            @Override
+            public void onRequest(@Nullable None payload, @NonNull ElectrodeBridgeResponseListener<None> responseListener) {
+                assertSame(None.NONE, payload);
+                responseListener.onSuccess(null);
+            }
+        }).execute();
+        assertTrue(requestHandle.isRegistered());
+        requestHandle.unregister();
+        assertFalse(requestHandle.isRegistered());
+    }
+
+    @Test
+    public void testRequestHandlerIsRegisteredOnReRegister() {
+        final String requestName = "testRequestHandlerRemoval";
+
+        RequestHandlerHandle requestHandle = new RequestHandlerProcessor<>(requestName, None.class, None.class, new ElectrodeBridgeRequestHandler<None, None>() {
+            @Override
+            public void onRequest(@Nullable None payload, @NonNull ElectrodeBridgeResponseListener<None> responseListener) {
+                assertSame(None.NONE, payload);
+                responseListener.onSuccess(null);
+            }
+        }).execute();
+        assertTrue(requestHandle.isRegistered());
+        RequestHandlerHandle newRequestHandle = new RequestHandlerProcessor<>(requestName, None.class, None.class, new ElectrodeBridgeRequestHandler<None, None>() {
+            @Override
+            public void onRequest(@Nullable None payload, @NonNull ElectrodeBridgeResponseListener<None> responseListener) {
+                assertSame(None.NONE, payload);
+                responseListener.onSuccess(null);
+            }
+        }).execute();
+        //Ensure a new request handler registration removes the old one
+        assertFalse(requestHandle.isRegistered());
+
+        assertTrue(newRequestHandle.isRegistered());
     }
 }

--- a/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeBridgeHolder.java
+++ b/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeBridgeHolder.java
@@ -223,6 +223,21 @@ public final class ElectrodeBridgeHolder {
         }
     }
 
+    public static boolean isRegistered(@NonNull UUID requestHandlerUuid) {
+        if (!isReactNativeReady) {
+            synchronized (mQueuedRequestHandlersRegistration) {
+                for (Map.Entry<String, RequestHandlerPlaceholder> entry : mQueuedRequestHandlersRegistration.entrySet()) {
+                    if (entry.getValue().getUUID() == requestHandlerUuid) {
+                        return true;
+                    }
+                }
+            }
+        } else {
+            return electrodeNativeBridge.isRegistered(requestHandlerUuid);
+        }
+        return false;
+    }
+
     private static void registerQueuedRequestHandlers() {
         for (Map.Entry<String, RequestHandlerPlaceholder> entry : mQueuedRequestHandlersRegistration.entrySet()) {
             electrodeNativeBridge.registerRequestHandler(

--- a/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeBridgeTransceiver.java
+++ b/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeBridgeTransceiver.java
@@ -152,6 +152,11 @@ class ElectrodeBridgeTransceiver extends ReactContextBaseJavaModule implements E
         return sRequestRegistrar.getRequestHandlerId(name);
     }
 
+    @Override
+    public boolean isRegistered(@NonNull UUID requestHandlerUuid) {
+        return sRequestRegistrar.isRegistered(requestHandlerUuid);
+    }
+
     @NonNull
     @Override
     public UUID getEventListenerId(@NonNull ElectrodeBridgeEventListener<ElectrodeBridgeEvent> eventListener) {

--- a/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeNativeBridge.java
+++ b/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeNativeBridge.java
@@ -44,6 +44,24 @@ public interface ElectrodeNativeBridge {
     boolean registerRequestHandler(@NonNull String name, @NonNull ElectrodeBridgeRequestHandler<ElectrodeBridgeRequest, Object> requestHandler, UUID uuid);
 
     /**
+     * Unregisters a request handler
+     *
+     * @param requestHandlerUuid {@link UUID} of registerRequestHandler
+     * @return registerRequestHandler unregistered
+     */
+    @SuppressWarnings("unused")
+    ElectrodeBridgeRequestHandler<ElectrodeBridgeRequest, Object> unregisterRequestHandler(@NonNull UUID requestHandlerUuid);
+
+    /**
+     * Query UUID of the request handler
+     *
+     * @param name
+     * @return {@link UUID} of the request handler
+     */
+    @Nullable
+    UUID getRequestHandlerId(@NonNull String name);
+
+    /**
      * Sends an event with some data to the all the even listeners.
      *
      * @param event {@link ElectrodeBridgeEvent} to emit
@@ -62,15 +80,6 @@ public interface ElectrodeNativeBridge {
     boolean addEventListener(@NonNull String name, @NonNull ElectrodeBridgeEventListener<ElectrodeBridgeEvent> eventListener, UUID uuid);
 
     /**
-     * Query UUID of the request handler
-     *
-     * @param name
-     * @return {@link UUID} of the request handler
-     */
-    @Nullable
-    UUID getRequestHandlerId(@NonNull String name);
-
-    /**
      * Query UUID of the event listener
      *
      * @param eventListener
@@ -86,14 +95,4 @@ public interface ElectrodeNativeBridge {
      * @return
      */
     ElectrodeBridgeEventListener<ElectrodeBridgeEvent> removeEventListener(@NonNull UUID eventListenerUuid);
-
-    /**
-     * Unregisters a request handler
-     *
-     * @param requestHandlerUuid {@link UUID} of registerRequestHandler
-     * @return registerRequestHandler unregistered
-     */
-    @SuppressWarnings("unused")
-    ElectrodeBridgeRequestHandler<ElectrodeBridgeRequest, Object> unregisterRequestHandler(@NonNull UUID requestHandlerUuid);
-
 }

--- a/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeNativeBridge.java
+++ b/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/ElectrodeNativeBridge.java
@@ -62,6 +62,14 @@ public interface ElectrodeNativeBridge {
     UUID getRequestHandlerId(@NonNull String name);
 
     /**
+     * Validates if the request handler associated with the id is still in registered state.
+     *
+     * @param requestHandlerUuid requestHandlerId
+     * @return true | false
+     */
+    boolean isRegistered(@NonNull UUID requestHandlerUuid);
+
+    /**
      * Sends an event with some data to the all the even listeners.
      *
      * @param event {@link ElectrodeBridgeEvent} to emit

--- a/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/RequestHandlerHandle.java
+++ b/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/RequestHandlerHandle.java
@@ -23,9 +23,16 @@ package com.walmartlabs.electrode.reactnative.bridge;
  */
 public interface RequestHandlerHandle {
     /**
-     * Unregisters a request handler.
+     * Checks if the request handler associated to this handle is still the registered handler
      *
-     * @return
+     * @return true | false
+     */
+    boolean isRegistered();
+
+    /**
+     * Unregisters a request handler if present
+     *
+     * @return true if the request handler was unregistered. false if the handler was already removed
      */
     boolean unregister();
 }

--- a/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/RequestHandlerProcessor.java
+++ b/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/RequestHandlerProcessor.java
@@ -91,7 +91,7 @@ public class RequestHandlerProcessor<TReq, TResp> implements RequestHandlerHandl
 
     @Override
     public boolean unregister() {
-        Logger.w(TAG, "Removing registered request handler %s with id %s", handler, id);
+        Logger.d(TAG, "Removing registered request handler %s with id %s", handler, id);
         ElectrodeBridgeHolder.unregisterRequestHandler(id);
         intermediateRequestHandler = null;
         handler = null;

--- a/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/RequestHandlerProcessor.java
+++ b/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/RequestHandlerProcessor.java
@@ -90,6 +90,11 @@ public class RequestHandlerProcessor<TReq, TResp> implements RequestHandlerHandl
     }
 
     @Override
+    public boolean isRegistered() {
+        return ElectrodeBridgeHolder.isRegistered(id);
+    }
+
+    @Override
     public boolean unregister() {
         Logger.d(TAG, "Removing registered request handler %s with id %s", handler, id);
         ElectrodeBridgeHolder.unregisterRequestHandler(id);

--- a/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/RequestRegistrar.java
+++ b/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/RequestRegistrar.java
@@ -61,4 +61,12 @@ public interface RequestRegistrar<T> {
      */
     @Nullable
     UUID getRequestHandlerId(@NonNull String name);
+
+    /**
+     * Validates if the request handler is still registered
+     *
+     * @param requestHandlerUuid requestHandler id
+     * @return true | false
+     */
+    boolean isRegistered(@NonNull UUID requestHandlerUuid);
 }

--- a/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/RequestRegistrarImpl.java
+++ b/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/RequestRegistrarImpl.java
@@ -93,6 +93,11 @@ public class RequestRegistrarImpl<T> implements RequestRegistrar<T> {
         return null;
     }
 
+    @Override
+    public boolean isRegistered(@NonNull UUID requestHandlerUuid) {
+        return mRequestNameByUUID.containsKey(requestHandlerUuid);
+    }
+
     private void removeOldUuidMapping(@NonNull String name) {
         UUID oldUuid = getRequestHandlerId(name);
         if (oldUuid != null) {

--- a/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/RequestRegistrarImpl.java
+++ b/android/electrode-reactnative-bridge/src/main/java/com/walmartlabs/electrode/reactnative/bridge/RequestRegistrarImpl.java
@@ -49,9 +49,8 @@ public class RequestRegistrarImpl<T> implements RequestRegistrar<T> {
         }
         mRequestHandlerByRequestName.put(name, requestHandler);
         mRequestNameByUUID.put(requestHandlerUuid, name);
-        isRegistered = true;
         Logger.d(TAG, "New request handler(id: %s) registered for request: %s", requestHandlerUuid, name);
-        return isRegistered;
+        return true;
     }
 
     /**


### PR DESCRIPTION
This PR adds `isRegistered` api to `RequestHandle`. This helps the consuming app to validate if a given request handler instance is still valid or it's already removed by a new request handler instance or removed via a call to `unregister()`. 